### PR TITLE
Minor UI improvement on attendance page

### DIFF
--- a/web-app/app/attendance/page.tsx
+++ b/web-app/app/attendance/page.tsx
@@ -16,6 +16,7 @@ export default function AttendancePage() {
             <div className="w-full space-y-4">
                 {mockAttendance
                     .filter((student) => student.status != "no-response")
+                    .sort((a, b) => (b.timestamp ?? "").localeCompare(a.timestamp ?? ""))
                     .map((student) => (
                         <StudentRow key={student.dotNumber} {...student} />
                     ))}

--- a/web-app/app/attendance/page.tsx
+++ b/web-app/app/attendance/page.tsx
@@ -4,13 +4,13 @@ import AttendanceCodeCard from "@/components/attendance/AttendanceCodeCard";
 
 export default function AttendancePage() {
     const code = "0000";
-    const meeting_date = "Sept. 24, 2025";
+    const meetingDate = new Date();
 
     return (
         <main className="flex flex-col items-center p-8 w-full max-w-3xl mx-auto">
             <h1 className="text-3xl font-bold mb-8">Attendance</h1>
 
-            <AttendanceCodeCard code={code} meetingDate={meeting_date} />
+            <AttendanceCodeCard code={code} meetingDate={meetingDate} />
 
             {/* Students who have responded */}
             <div className="w-full space-y-4">

--- a/web-app/app/attendance/page.tsx
+++ b/web-app/app/attendance/page.tsx
@@ -16,7 +16,11 @@ export default function AttendancePage() {
             <div className="w-full space-y-4">
                 {mockAttendance
                     .filter((student) => student.status != "no-response")
-                    .sort((a, b) => (b.timestamp ?? "").localeCompare(a.timestamp ?? ""))
+                    .sort((a, b) => {
+                        const dateA = a.timestamp ? new Date(a.timestamp) : new Date(0);
+                        const dateB = b.timestamp ? new Date(b.timestamp) : new Date(0);
+                        return dateB.getTime() - dateA.getTime();
+                    })
                     .map((student) => (
                         <StudentRow key={student.dotNumber} {...student} />
                     ))}

--- a/web-app/bun.lock
+++ b/web-app/bun.lock
@@ -4,6 +4,7 @@
     "": {
       "name": "web-app",
       "dependencies": {
+        "@radix-ui/react-slot": "^1.2.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.542.0",
@@ -146,6 +147,10 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
+
+    "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
+
+    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 

--- a/web-app/components/attendance/AttendanceCodeCard.tsx
+++ b/web-app/components/attendance/AttendanceCodeCard.tsx
@@ -11,13 +11,13 @@ export default function AttendanceCodeCard({
     meetingDate,
 }: {
     code: string;
-    meetingDate: string;
+    meetingDate: Date;
 }) {
     return (
         <Card className="flex flex-col md:flex-row items-center gap-8 shadow-md rounded-2xl p-8 mb-14">
             <CardContent className="text-center">
                 <CardTitle className="text-lg mb-2">
-                    {meetingDate} Attendance Code
+                    {meetingDate.toLocaleDateString()}
                 </CardTitle>
                 <p className="text-5xl font-mono font-bold tracking-widest text-blue-600">
                     {code}

--- a/web-app/components/attendance/StudentRow.tsx
+++ b/web-app/components/attendance/StudentRow.tsx
@@ -62,7 +62,7 @@ export function StudentRow({
 }: StudentProps) {
     return (
         <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
+            <div className="flex items-baseline gap-2">
                 <p className="font-medium">{name}</p>
                 <p className="text-sm text-gray-400">{dotNumber}</p>
             </div>

--- a/web-app/components/attendance/StudentRow.tsx
+++ b/web-app/components/attendance/StudentRow.tsx
@@ -2,7 +2,7 @@
 
 import { AttendanceStatus, StudentProps } from "@/types/student-attendance";
 import { Badge } from "@/components/ui/badge";
-import { CheckCircle, Clock, XCircle, HelpCircle } from "lucide-react";
+import { CheckCircle, Clock, XCircle, HelpCircle, Flame } from "lucide-react";
 
 const StatusBadge = ({ status }: { status: AttendanceStatus }) => {
     const getVariantAndText = (status: AttendanceStatus) => {
@@ -70,7 +70,10 @@ export function StudentRow({
             <div className="flex items-center gap-6">
                 <StatusBadge status={status} />
                 <p className="text-sm text-gray-600">{timestamp ?? "--:--"}</p>
-                <p className="text-sm text-gray-600">🔥 {streak}</p>
+                <Badge variant="secondary" className="bg-orange-100 text-orange-700 border-orange-200">
+                    <Flame size={14} />
+                    {streak}
+                </Badge>
             </div>
         </div>
     );

--- a/web-app/components/attendance/StudentRow.tsx
+++ b/web-app/components/attendance/StudentRow.tsx
@@ -16,7 +16,7 @@ const StatusBadge = ({ status }: { status: AttendanceStatus }) => {
                 };
             case "late":
                 return {
-                    variant: "secondary" as const,
+                    variant: "default" as const,
                     text: "Late",
                     className: "bg-yellow-500 text-white",
                     icon: <Clock size={14} />
@@ -70,7 +70,7 @@ export function StudentRow({
             <div className="flex items-center gap-6">
                 <StatusBadge status={status} />
                 <p className="text-sm text-gray-600">{timestamp ?? "--:--"}</p>
-                <Badge variant="secondary" className="bg-orange-100 text-orange-700 border-orange-200">
+                <Badge variant="default" className="bg-orange-100 text-orange-700 border-orange-200">
                     <Flame size={14} />
                     {streak}
                 </Badge>

--- a/web-app/components/attendance/StudentRow.tsx
+++ b/web-app/components/attendance/StudentRow.tsx
@@ -1,6 +1,57 @@
 "use client";
 
-import { StudentProps } from "@/types/student-attendance";
+import { AttendanceStatus, StudentProps } from "@/types/student-attendance";
+import { Badge } from "@/components/ui/badge";
+import { CheckCircle, Clock, XCircle, HelpCircle } from "lucide-react";
+
+const StatusBadge = ({ status }: { status: AttendanceStatus }) => {
+    const getVariantAndText = (status: AttendanceStatus) => {
+        switch (status) {
+            case "present":
+                return {
+                    variant: "default" as const,
+                    text: "Present",
+                    className: "bg-green-500 text-white",
+                    icon: <CheckCircle size={14} />
+                };
+            case "late":
+                return {
+                    variant: "secondary" as const,
+                    text: "Late",
+                    className: "bg-yellow-500 text-white",
+                    icon: <Clock size={14} />
+                };
+            case "absent":
+                return {
+                    variant: "destructive" as const,
+                    text: "Absent",
+                    icon: <XCircle size={14} />
+                };
+            case "no-response":
+                return {
+                    variant: "outline" as const,
+                    text: "No Response",
+                    className: "text-gray-500",
+                    icon: <HelpCircle size={14} />
+                };
+            default:
+                return {
+                    variant: "outline" as const,
+                    text: "Unknown",
+                    icon: <HelpCircle size={14} />
+                };
+        }
+    };
+
+    const { variant, text, className, icon } = getVariantAndText(status);
+
+    return (
+        <Badge variant={variant} className={className}>
+            {icon}
+            {text}
+        </Badge>
+    );
+}
 
 export function StudentRow({
     name,
@@ -17,7 +68,7 @@ export function StudentRow({
             </div>
 
             <div className="flex items-center gap-6">
-                <span>{status}</span>
+                <StatusBadge status={status} />
                 <p className="text-sm text-gray-600">{timestamp ?? "--:--"}</p>
                 <p className="text-sm text-gray-600">🔥 {streak}</p>
             </div>

--- a/web-app/components/attendance/StudentRow.tsx
+++ b/web-app/components/attendance/StudentRow.tsx
@@ -4,55 +4,6 @@ import { AttendanceStatus, StudentProps } from "@/types/student-attendance";
 import { Badge } from "@/components/ui/badge";
 import { CheckCircle, Clock, XCircle, HelpCircle, Flame } from "lucide-react";
 
-const StatusBadge = ({ status }: { status: AttendanceStatus }) => {
-    const getVariantAndText = (status: AttendanceStatus) => {
-        switch (status) {
-            case "present":
-                return {
-                    variant: "default" as const,
-                    text: "Present",
-                    className: "bg-green-500 text-white",
-                    icon: <CheckCircle size={14} />
-                };
-            case "late":
-                return {
-                    variant: "default" as const,
-                    text: "Late",
-                    className: "bg-yellow-500 text-white",
-                    icon: <Clock size={14} />
-                };
-            case "absent":
-                return {
-                    variant: "destructive" as const,
-                    text: "Absent",
-                    icon: <XCircle size={14} />
-                };
-            case "no-response":
-                return {
-                    variant: "outline" as const,
-                    text: "No Response",
-                    className: "text-gray-500",
-                    icon: <HelpCircle size={14} />
-                };
-            default:
-                return {
-                    variant: "outline" as const,
-                    text: "Unknown",
-                    icon: <HelpCircle size={14} />
-                };
-        }
-    };
-
-    const { variant, text, className, icon } = getVariantAndText(status);
-
-    return (
-        <Badge variant={variant} className={className}>
-            {icon}
-            {text}
-        </Badge>
-    );
-}
-
 export function StudentRow({
     name,
     dotNumber,
@@ -78,3 +29,42 @@ export function StudentRow({
         </div>
     );
 }
+
+const StatusBadge = ({ status }: { status: AttendanceStatus }) => {
+    const statusConfig = {
+        present: {
+            variant: "default" as const,
+            text: "Present",
+            className: "bg-green-500 text-white",
+            icon: <CheckCircle size={14} />,
+        },
+        late: {
+            variant: "default" as const,
+            text: "Late",
+            className: "bg-yellow-500 text-white",
+            icon: <Clock size={14} />,
+        },
+        absent: {
+            variant: "destructive" as const,
+            text: "Absent",
+            icon: <XCircle size={14} />,
+        },
+        "no-response": {
+            variant: "outline" as const,
+            text: "No Response",
+            className: "text-gray-500",
+            icon: <HelpCircle size={14} />,
+        },
+    }[status] || {
+        variant: "outline" as const,
+        text: "Unknown",
+        icon: <HelpCircle size={14} />,
+    };
+
+    return (
+        <Badge variant={statusConfig.variant} className={statusConfig.className}>
+            {statusConfig.icon}
+            {statusConfig.text}
+        </Badge>
+    );
+};

--- a/web-app/components/ui/badge.tsx
+++ b/web-app/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.542.0",


### PR DESCRIPTION
* Added shadcn/ui `Badge` component.
* Updated `StudentRow` in `web-app/components/attendance/StudentRow.tsx` to display attendance status and streak using the `Badge` component, replacing plain text. [[1]](diffhunk://#diff-165273d6eb280e3aed2af49526ff7587cbffd6f85061154a8586c5cffabba30fL3-R54) [[2]](diffhunk://#diff-165273d6eb280e3aed2af49526ff7587cbffd6f85061154a8586c5cffabba30fL14-R76)
* Changed the `meetingDate` prop in `AttendanceCodeCard` to use a `Date` object instead of a string. [[1]](diffhunk://#diff-5fee0fa35e21cb52cba41424f1f117b144f43cce34b7fc9123e6f971b7353d5aL7-R19) [[2]](diffhunk://#diff-8768dce2e9be88dfdf4defd5960d80a92faf88e709fb2855f0c537c909a3c8c6L14-R20)
* Sorted the list of students who have responded by timestamp.